### PR TITLE
Make Token Light Picker use lightAngle

### DIFF
--- a/misc/Token_Light_Picker.js
+++ b/misc/Token_Light_Picker.js
@@ -5,42 +5,42 @@ let dialogEditor = new Dialog({
     none: {
       label: `None`,
       callback: () => {
-        token.update({"dimLight": 0, "brightLight": 0, "sightAngle": 360,});
+        token.update({"dimLight": 0, "brightLight": 0, "lightAngle": 360,});
         dialogEditor.render(true);
       }
     },
     torch: {
       label: `Torch`,
       callback: () => {
-        token.update({"dimLight": 40, "brightLight": 20, "sightAngle": 360,});
+        token.update({"dimLight": 40, "brightLight": 20, "lightAngle": 360,});
         dialogEditor.render(true);
       }
     },
     lamp: {
       label: `Lamp`,
       callback: () => {
-        token.update({"dimLight": 45, "brightLight": 15, "sightAngle": 360,});
+        token.update({"dimLight": 45, "brightLight": 15, "lightAngle": 360,});
         dialogEditor.render(true);
       }
     },
     bullseye: {
       label: `Bullseye Lantern`,
       callback: () => {
-        token.update({"dimLight": 120, "brightLight": 60, "sightAngle": 45,});
+        token.update({"dimLight": 120, "brightLight": 60, "lightAngle": 45,});
         dialogEditor.render(true);
       }
     },
     hoodedOpen: {
       label: `Hooded Lantern (Open)`,
       callback: () => {
-        token.update({"dimLight": 60, "brightLight": 30, "sightAngle": 360,});
+        token.update({"dimLight": 60, "brightLight": 30, "lightAngle": 360,});
         dialogEditor.render(true);
       }
     },
     hoodedClosed: {
       label: `Hooded Lantern (Closed)`,
       callback: () => {
-        token.update({"dimLight": 5, "brightLight": 0, "sightAngle": 360,});
+        token.update({"dimLight": 5, "brightLight": 0, "lightAngle": 360,});
         dialogEditor.render(true);
       }
     },


### PR DESCRIPTION
This should be setting `lightAngle` instead of `sightAngle` so the proper light appears to others.