### PR TITLE
fix(rage): ensure that the actor sheet updates correctly if it is open

### DIFF
--- a/actor/rage.js
+++ b/actor/rage.js
@@ -108,6 +108,10 @@ if (actor !== undefined && actor !== null) {
 					ui.notifications.warn(`${actor.name} does not have any rage left, time for a rest!`);
 					return;
 				}
+				if (actor.sheet.rendered) {
+					// Update the actor sheet if it is currently open
+					actor.render(true);
+				}
 			}
 
 			chatMsg = `${actor.name} is RAAAAAGING!`;


### PR DESCRIPTION
If the actor sheet was open at the time of running the macro, the resource count would not correctly reduce if you were on a tab showing that resource. This has been fixed.