### PR TITLE
Create dice rollers (for cure light wounds, channel positive energy, knowledge (any))

### DIFF
--- a/roll/hit_target_healing.js
+++ b/roll/hit_target_healing.js
@@ -1,0 +1,78 @@
+// this script attempts to heal X points of damage by repeatedly using charges of wands of cure light wounds
+
+function hitTarget(target) {
+  if (target > 250) {
+    ui.notifications.warn(
+      "Too much healing! No one needs that much healing! Max 250."
+    );
+    return;
+  }
+  let current = 0;
+  let chargesUsed;
+
+  const rolls = [];
+  for (chargesUsed = 0; current < target; chargesUsed += 1) {
+    const roll = new Roll("1d8 + 1");
+    roll.roll();
+    current += roll.total;
+    rolls.push({ roll: roll.total - 1 });
+  }
+
+  const roll = new Roll(`${chargesUsed}d8 + ${chargesUsed}`);
+  const msg = roll.toMessage(
+    { flavor: `Casting <i>cure light wounds</i> ${chargesUsed} times` },
+    { create: false }
+  );
+
+  const fakeRoll = {
+    class: "Roll",
+    formula: `${chargesUsed}d8 + ${chargesUsed}`,
+    dice: [
+      {
+        class: "Die",
+        faces: 8,
+        rolls: rolls,
+        formula: `${chargesUsed}d8`,
+        options: {},
+      },
+    ],
+    parts: ["_d0", "+", `${chargesUsed}`],
+    result: `${current - chargesUsed} + ${chargesUsed}`,
+    total: current,
+  };
+
+  msg.roll = JSON.stringify(fakeRoll);
+  msg.content = String(current);
+
+  const tokens = canvas.tokens.controlled;
+  if (tokens.length !== 1) {
+    ui.notifications.warn("Please select a token.");
+    return;
+  }
+  const token = tokens[0];
+  msg.speaker = {alias: token.actor.data.name}
+
+  ChatMessage.create(msg);
+}
+
+new Dialog({
+  title: "Cast until heal a set amount",
+  content:
+    "<p>Enter the amount you want to heal</p><center><input type='number' id='amountInput'></center><br>",
+  buttons: {
+    submit: {
+      label: "Heal",
+      icon: '<i class="fas fa-medkit"></i>',
+      callback: () => {
+        const healTarget = parseInt(
+          eval(
+            $("#amountInput")
+              .val()
+              .match(/[0-9]*/g)
+          )
+        );
+        hitTarget(healTarget);
+      },
+    },
+  },
+}).render(true);

--- a/roll/roll_channel_positive_healing.js
+++ b/roll/roll_channel_positive_healing.js
@@ -1,0 +1,31 @@
+// CONFIGURATION
+// Leave casterName as null to channel positive as the currently-selected character
+// Example `const casterName = "Bob Bobbington";`
+const casterName = null;
+
+const tokens = canvas.tokens.controlled;
+let caster = tokens.map((o) => o.actor)[0];
+if (!caster && !!casterName) {
+    caster = game.actors.entities.filter((o) => o.name.includes(casterName))[0];
+}
+
+function channelPositive() {
+  if (!caster.data.data.classes.cleric) {
+    ui.notifications.warn("You're not a cleric!");
+    return;
+  }
+  const clericLevel = caster.data.data.classes.cleric.level;
+  const rollString = `${(clericLevel + 1) / 2}d6`;
+
+  const roll = new Roll(rollString);
+  roll.roll();
+  roll.toMessage({
+    flavor: "Channeling positive energy",
+  });
+}
+
+if (!caster || caster === undefined) {
+  ui.notifications.warn("You need to be controlling someone to channel!")
+} else {
+  channelPositive();
+}

--- a/roll/roll_channel_positive_healing.js
+++ b/roll/roll_channel_positive_healing.js
@@ -15,7 +15,7 @@ function channelPositive() {
     return;
   }
   const clericLevel = caster.data.data.classes.cleric.level;
-  const rollString = `${(clericLevel + 1) / 2}d6`;
+  const rollString = `${Math.floor((clericLevel + 1) / 2)}d6`;
 
   const roll = new Roll(rollString);
   roll.roll();

--- a/roll/roll_knowledge_skill_check.js
+++ b/roll/roll_knowledge_skill_check.js
@@ -1,0 +1,58 @@
+const tokens = canvas.tokens.controlled;
+const caster = tokens[0];
+
+if (tokens.length !== 1) {
+  ui.notifications.warn("Please select a token");
+} else {
+  const knowledgeTypes = [
+    "Arcana",
+    "Dungeoneering",
+    "Engineering",
+    "Geography",
+    "History",
+    "Local",
+    "Nature",
+    "Nobility",
+    "Planes",
+    "Religion",
+  ];
+
+  const knowledgeData = [];
+  knowledgeTypes.forEach((type) => {
+    const knowledgeDatum =
+      caster.actor.data.data.skills[`k${type.toLowerCase().substring(0, 2)}`];
+    knowledgeDatum.name = type;
+    knowledgeData.push(knowledgeDatum);
+  });
+
+  const knownKnowledge = knowledgeData.filter((datum) => datum.rank > 0);
+
+  if (knownKnowledge.length < 1) {
+    ui.notifications.warn("You know nothing.");
+  } else {
+    const buttons = {};
+    knownKnowledge.forEach((type) => {
+      buttons[type.name] = {
+        label: type.name,
+        callback: () => {
+          rollCheck(type.name, type.mod);
+        },
+      };
+    });
+
+    new Dialog({
+      title: "Roll Knowledge!",
+      content: `<p>Choose a knowledge skill</p>`,
+      buttons: buttons,
+    }).render(true);
+  }
+}
+
+function rollCheck(name, mod) {
+  const roll = new Roll(`1d20 + ${mod}`);
+  roll.roll();
+  roll.toMessage({
+    flavor: `Knowledge ${name} check`,
+    speaker: { alias: token.actor.data.name },
+  });
+}


### PR DESCRIPTION
Created the following scripts for my players to use and thought they might be helpful to others.
We play Pathfinder 1e, so the scripts might need some modification to suit other systems (specifically DND5e and pf2e).

Brief summaries:

- hit_target_healing: enter a value and the script will roll 1d8+1 (simulating castings of _cure light wounds_ wands) until that number is hit.

- roll_channel_positive_healing: gets the user's cleric level and rolls an appropriate amount of dice for that level. 

- roll_knowledge_skill_check: a macro for players to click. If they have at least 1 rank in any of the knowledge skills, spawns a dialogue with a button for each skill. Click button to roll that knowledge skill (with modifier).