### PR TITLE
Prevent race conditions in shrink_or_enlarge.js

### DIFF
--- a/token/shrink_or_enlarge.js
+++ b/token/shrink_or_enlarge.js
@@ -1,9 +1,15 @@
 // Update selected tokens to flip between a 1x1 or a 2x2 grid.
 
+const updates = [];
 for (let token of canvas.tokens.controlled) {
   let newSize = (token.data.height == 1 && token.data.width == 1) ? 2 : 1;
-  token.update({
+  updates.push({
+    _id: token.id,
     height: newSize,
     width: newSize
   });
 };
+
+// use `canvas.tokens.updateMany` instead of `token.update` to prevent race conditions
+// (meaning not all updates will be persisted and might only show locally)
+canvas.tokens.updateMany(updates);


### PR DESCRIPTION
Looping over entities and calling `update` on them can cause race conditions in which not all updates will be persisted successfully.
By creating an array of updates and using `updateMany`, this is prevented.