### PR TITLE
Adding check for PC owned characters

### DIFF
--- a/misc/award_party_xp.js
+++ b/misc/award_party_xp.js
@@ -2,7 +2,7 @@
 {
   function award_xp(type, amount)
   {
-    let actors = game.actors.entities.filter(e => e.data.type === 'character');
+    let actors = game.actors.entities.filter(e => e.data.type === 'character' && e.isPC);
     let isShared = type == "shared";
     console.log(type + ' ' + amount);
     if (Number.isInteger(amount) && actors.length > 0)


### PR DESCRIPTION
As the DM, I have a few characters I use for testing, whether it be items or for combat. Using the macro unfortunately also awards exp to those testing characters.