### PR TITLE
Adding Moon-Touched as a lighting option

### DIFF
--- a/token/token_vision_config.js
+++ b/token/token_vision_config.js
@@ -31,7 +31,7 @@ new Dialog({
           <option value="hooded-bright">Lantern (Hooded - Bright)</option>
           <option value="light">Light (Cantrip)</option>
           <option value="torch">Torch</option>
-		  <option value="moon-touched">Moon-Touched</option>
+          <option value="moon-touched">Moon-Touched</option>
         </select>
       </div>
     </form>
@@ -134,10 +134,10 @@ new Dialog({
             dimLight = 40;
             brightLight = 20;
             break;
-		  case "moon-touched":
-			dimLight = 30;
-			brightLight = 15;
-			break;
+          case "moon-touched":
+            dimLight = 30;
+            brightLight = 15;
+            break;
           case "nochange":
           default:
             dimLight = token.data.dimLight;

--- a/token/token_vision_config.js
+++ b/token/token_vision_config.js
@@ -17,7 +17,6 @@ new Dialog({
           <option value="dim150">Darkvision (150 ft)</option>
           <option value="dim180">Darkvision (180 ft)</option>
           <option value="bright120">Devil's Sight (Warlock)</option>
-		  <option value="moon-touched">Moon-Touched</option>
         </select>
       </div>
       <div class="form-group">
@@ -32,7 +31,7 @@ new Dialog({
           <option value="hooded-bright">Lantern (Hooded - Bright)</option>
           <option value="light">Light (Cantrip)</option>
           <option value="torch">Torch</option>
-		  <option value="moon-touched>Moon-Touched</option>
+		  <option value="moon-touched">Moon-Touched</option>
         </select>
       </div>
     </form>
@@ -135,7 +134,7 @@ new Dialog({
             dimLight = 40;
             brightLight = 20;
             break;
-		  case "moon-touched"
+		  case "moon-touched":
 			dimLight = 30;
 			brightLight = 15;
 			break;

--- a/token/token_vision_config.js
+++ b/token/token_vision_config.js
@@ -17,6 +17,7 @@ new Dialog({
           <option value="dim150">Darkvision (150 ft)</option>
           <option value="dim180">Darkvision (180 ft)</option>
           <option value="bright120">Devil's Sight (Warlock)</option>
+		  <option value="moon-touched">Moon-Touched</option>
         </select>
       </div>
       <div class="form-group">
@@ -31,6 +32,7 @@ new Dialog({
           <option value="hooded-bright">Lantern (Hooded - Bright)</option>
           <option value="light">Light (Cantrip)</option>
           <option value="torch">Torch</option>
+		  <option value="moon-touched>Moon-Touched</option>
         </select>
       </div>
     </form>
@@ -133,6 +135,10 @@ new Dialog({
             dimLight = 40;
             brightLight = 20;
             break;
+		  case "moon-touched"
+			dimLight = 30;
+			brightLight = 15;
+			break;
           case "nochange":
           default:
             dimLight = token.data.dimLight;


### PR DESCRIPTION
There's a common magic item in 5e DnD called a Moon-Touched Weapon. Makes your weapon shed light in a certain radius, 15 feet bright and then another 15 feet of of dim.

I've added the option to the end of the lighting effects.