### PR TITLE
light_picker.js: Torch animations + light cantrip

### DIFF
--- a/token/light_picker.js
+++ b/token/light_picker.js
@@ -2,6 +2,8 @@ function tokenUpdate(data) {
   canvas.tokens.controlled.map(token => token.update(data));
 }
 
+let torchAnimation = {"type": "torch", "speed": 1, "intensity": 1};
+
 let dialogEditor = new Dialog({
   title: `Token Light Picker`,
   content: `Pick the light source the selected token is holding.`,
@@ -16,35 +18,42 @@ let dialogEditor = new Dialog({
     torch: {
       label: `Torch`,
       callback: () => {
-        tokenUpdate({"dimLight": 40, "brightLight": 20, "lightAngle": 360,});
+        tokenUpdate({"dimLight": 40, "brightLight": 20, "lightAngle": 360, "lightAnimation": torchAnimation});
+        dialogEditor.render(true);
+      }
+    },
+    light: {
+      label: `Light cantrip`,
+      callback: () => {
+        tokenUpdate({"dimLight": 40, "brightLight": 20, "lightAngle": 360, "lightAnimation": {"type": "none"}});
         dialogEditor.render(true);
       }
     },
     lamp: {
       label: `Lamp`,
       callback: () => {
-        tokenUpdate({"dimLight": 45, "brightLight": 15, "lightAngle": 360,});
+        tokenUpdate({"dimLight": 45, "brightLight": 15, "lightAngle": 360, "lightAnimation": torchAnimation});
         dialogEditor.render(true);
       }
     },
     bullseye: {
       label: `Bullseye Lantern`,
       callback: () => {
-        tokenUpdate({"dimLight": 120, "brightLight": 60, "lightAngle": 45,});
+        tokenUpdate({"dimLight": 120, "brightLight": 60, "lightAngle": 45, "lightAnimation": torchAnimation});
         dialogEditor.render(true);
       }
     },
     hoodedOpen: {
       label: `Hooded Lantern (Open)`,
       callback: () => {
-        tokenUpdate({"dimLight": 60, "brightLight": 30, "lightAngle": 360,});
+        tokenUpdate({"dimLight": 60, "brightLight": 30, "lightAngle": 360, "lightAnimation": torchAnimation});
         dialogEditor.render(true);
       }
     },
     hoodedClosed: {
       label: `Hooded Lantern (Closed)`,
       callback: () => {
-        tokenUpdate({"dimLight": 5, "brightLight": 0, "lightAngle": 360,});
+        tokenUpdate({"dimLight": 5, "brightLight": 0, "lightAngle": 360, "lightAnimation": torchAnimation});
         dialogEditor.render(true);
       }
     },


### PR DESCRIPTION
Add torch animations to all flame-based light sources, add a light cantrip light source that has no animation.