### PR TITLE
Add new macro to print tokens resistances

### DIFF
--- a/5e/show_tokens_resistances.js
+++ b/5e/show_tokens_resistances.js
@@ -8,7 +8,13 @@
 const damageTypes = ["Acid", "Bludgeoning", "Cold", "Fire", "Force", "Lightning", "Necrotic", "Piercing", "Poison", "Psychic", "Radiant", "Slashing", "Thunder"];
 
 let msg = "";
-let previousMessage = game.messages.entries[game.messages.entries.length-1].data.content;
+let previousMessage;
+try { 
+    previousMessage = game.messages.entries[game.messages.entries.length-1].data.content;
+} catch (e) {
+    // No previous message in log. Default to an empty string.
+    previousMessage = "";
+}
 
 // Enable case-insensitive replacements
 // Source: https://stackoverflow.com/a/7313467

--- a/5e/show_tokens_resistances.js
+++ b/5e/show_tokens_resistances.js
@@ -5,7 +5,9 @@
 // Author: https://github.com/Nijin22
 // Licence: MIT, see https://choosealicense.com/licenses/mit/
 
-const damageTypes = ["Acid", "Bludgeoning", "Cold", "Fire", "Force", "Lightning", "Necrotic", "Piercing", "Poison", "Psychic", "Radiant", "Slashing", "Thunder"];
+const damageTypes = ["Acid", "Bludgeoning", "Cold", "Fire", "Force", "Lightning", "Necrotic", "Piercing", "Non-Magical Physical",
+                     "Piercing", "Poison", "Psychic", "Radiant", "Slashing", "Thunder",
+                     "Bludgeoning, Piercing, and Slashing from Nonmagical Attacks"];
 
 let msg = "";
 let previousMessage;
@@ -25,24 +27,30 @@ String.prototype.replaceAllCaseInsensitive = function(strReplace, strWith) {
     return this.replace(reg, strWith);
 };
 
+
+// Get traits
+const traits = new Map();
+traits.set("ci", "Condition Immunities");
+traits.set("di", "Damage Immunities (No damage)");
+traits.set("dr", "Damage Resistances (Half damage)");
+traits.set("dv", "Damage Vulnerabilities (Double dmg)");
 canvas.tokens.controlled.forEach(token => {
     let name = token.actor.name;
-    let conditionImmunities = token.actor.data.data.traits.ci.value.join(", ");
-    if (conditionImmunities.length === 0) {conditionImmunities = "-"}
-    let damageImmunities = token.actor.data.data.traits.di.value.join(", ");
-    if (damageImmunities.length === 0) {damageImmunities = "-"}
-    let damageResistances = token.actor.data.data.traits.dr.value.join(", ");
-    if (damageResistances.length === 0) {damageResistances = "-"}
-    let damageVulnerabilities = token.actor.data.data.traits.dv.value.join(", ");
-    if (damageVulnerabilities.length === 0) {damageVulnerabilities = "-"}
+    msg += `<h2>${name}</h2>`;
     
-    msg += `
-        <h2>${name}</h2>
-        <h3>Condition Immunities</h3> <p>${conditionImmunities}</p>
-        <h3>Damage Immunities (No damage)</h3> <p>${damageImmunities}</p>
-        <h3>Damage Resistances (Half damage)</h3> <p>${damageResistances}</p>
-        <h3>Damage Vulnerabilities (Double dmg)</h3> <p>${damageVulnerabilities}</p>
-    `;
+    traits.forEach((traitDescr, traitId, map) => {
+        // Clone 'default' 5e trait array
+        var allTraits = [...token.actor.data.data.traits[traitId].value];
+        
+        // Custom traits
+        allTraits = allTraits.concat(token.actor.data.data.traits[traitId].custom.split(";").map(x => x.trim()));
+        
+        var printableTraits = allTraits.join("; ");
+        if (printableTraits.length == 0) {
+            printableTraits = "-";
+        }
+        msg += `<h3>${traitDescr}</h3><p>${printableTraits}</p>`;
+    });
 });
 
 // highlight words from previous message
@@ -61,8 +69,10 @@ if (msg.length === 0) {
     msg = "No tokens selected.";
 }
 
+ui.notifications.info(msg);
+
 // Post message to self
-ChatMessage.create({
+/*ChatMessage.create({
     content: msg,
     whisper: [game.user._id]
-});
+});*/

--- a/5e/show_tokens_resistances.js
+++ b/5e/show_tokens_resistances.js
@@ -1,0 +1,62 @@
+// Prints the condition immunities, damage immunities, damage resistances and damage vulnerabilities of the currently selected token(s).
+// Damage types that appeared in the previous chat message (e.g. due to a roll) are highlighted in red. 
+// A DM can call this macro after a player rolled damage to quickly see if they need to apply full, half or double damage.
+//
+// Author: https://github.com/Nijin22
+// Licence: MIT, see https://choosealicense.com/licenses/mit/
+
+const damageTypes = ["Acid", "Bludgeoning", "Cold", "Fire", "Force", "Lightning", "Necrotic", "Piercing", "Poison", "Psychic", "Radiant", "Slashing", "Thunder"];
+
+let msg = "";
+let previousMessage = game.messages.entries[game.messages.entries.length-1].data.content;
+
+// Enable case-insensitive replacements
+// Source: https://stackoverflow.com/a/7313467
+String.prototype.replaceAllCaseInsensitive = function(strReplace, strWith) {
+    // See http://stackoverflow.com/a/3561711/556609
+    var esc = strReplace.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    var reg = new RegExp(esc, 'ig');
+    return this.replace(reg, strWith);
+};
+
+canvas.tokens.controlled.forEach(token => {
+    let name = token.actor.name;
+    let conditionImmunities = token.actor.data.data.traits.ci.value.join(", ");
+    if (conditionImmunities.length === 0) {conditionImmunities = "-"}
+    let damageImmunities = token.actor.data.data.traits.di.value.join(", ");
+    if (damageImmunities.length === 0) {damageImmunities = "-"}
+    let damageResistances = token.actor.data.data.traits.dr.value.join(", ");
+    if (damageResistances.length === 0) {damageResistances = "-"}
+    let damageVulnerabilities = token.actor.data.data.traits.dv.value.join(", ");
+    if (damageVulnerabilities.length === 0) {damageVulnerabilities = "-"}
+    
+    msg += `
+        <h2>${name}</h2>
+        <h3>Condition Immunities</h3> <p>${conditionImmunities}</p>
+        <h3>Damage Immunities (No damage)</h3> <p>${damageImmunities}</p>
+        <h3>Damage Resistances (Half damage)</h3> <p>${damageResistances}</p>
+        <h3>Damage Vulnerabilities (Double dmg)</h3> <p>${damageVulnerabilities}</p>
+    `;
+});
+
+// highlight words from previous message
+let damageTypesOfPrevousMsg = [];
+damageTypes.forEach(damageType => {
+    if (previousMessage.toLowerCase().indexOf(damageType.toLowerCase()) != -1){
+        damageTypesOfPrevousMsg.push(damageType);
+    }
+});
+damageTypesOfPrevousMsg.forEach(damageType => {
+    msg = msg.replaceAllCaseInsensitive(damageType, `<span style="color:red; font-weight: bold;">${damageType}</span>`);
+});
+
+
+if (msg.length === 0) {
+    msg = "No tokens selected.";
+}
+
+// Post message to self
+ChatMessage.create({
+    content: msg,
+    whisper: [game.user._id]
+});


### PR DESCRIPTION
The macro prints the condition immunities, damage immunities, damage resistances and damage vulnerabilities of the currently selected token(s). Damage types that appeared in the previous chat message (e.g. due to a roll) are highlighted in red. A DM can call this macro after a player rolled damage to quickly see if they need to apply full, half or double damage.

Looks like that:
![print_resistance](https://user-images.githubusercontent.com/6653765/101240562-30942c00-36f0-11eb-8e74-8816a1d89640.gif)

![2020-12-05_11:36:40](https://user-images.githubusercontent.com/6653765/101240348-17d74680-36ef-11eb-9877-4e3b1a470186.png)

# TODO:
- [X] Parse `Bludgeoning, Piercing, and Slashing from Nonmagical Attacks` correctly. (E.g. [Vampire Spawn](https://www.dndbeyond.com/monsters/vampire-spawn))
