### PR TITLE
Create clone_token_actor.js

### DIFF
--- a/token/clone_token_actor.js
+++ b/token/clone_token_actor.js
@@ -1,0 +1,10 @@
+// Clones actor details from the selected token(s) into a new Actor in the item list.
+// Useful if you made changes to the actor associated with the token, but want to save that
+//  updated Actor for later use or into a Compendium.
+// Created Actor will default to the name of the token with the actorNameSuffix (default: '_cloned')
+
+const actorNameSuffix = "_cloned";
+
+canvas.tokens.controlled.forEach(o => {
+  o.actor.clone({ name: o.name + actorNameSuffix });
+});


### PR DESCRIPTION
Clones actor details from the selected token(s) into a new Actor in the item list. Useful if you made changes to the actor associated with the token, but want to save that updated Actor for later use or into a Compendium.