### PR TITLE
Fixed duplicated 1d4 on skills checks

### DIFF
--- a/5e/guidance.js
+++ b/5e/guidance.js
@@ -24,7 +24,6 @@ if (macroToken === undefined || macroToken === null) {
 } else {
 // grab curent global states
 	let abilities = JSON.parse(JSON.stringify(macroActor.data.data.bonuses.abilities.check));
-	let skills = JSON.parse(JSON.stringify(macroActor.data.data.bonuses.abilities.skill));
 	if(abilities.includes(Guidd4)){
 		guided = true;
 	}
@@ -38,7 +37,6 @@ if (macroToken === undefined || macroToken === null) {
 		console.log('adding guidance modifiers to global bonuses');
 		let obj = {};
 		obj['data.bonuses.abilities.check'] = abilities + Guidd4;
-		obj['data.bonuses.abilities.skill'] = skills + Guidd4;
 		macroActor.update(obj);
 // if already guided	
 	}	else if (guided == true) {
@@ -53,10 +51,6 @@ if (macroToken === undefined || macroToken === null) {
 		var tmpLength = tmp.indexOf(Guidd4);
         tmp = tmp.substring(0, tmpLength) + tmp.substring(tmpLength+4, tmp.length);
 		obj['data.bonuses.abilities.check'] = tmp;
-		var tmp = JSON.parse(JSON.stringify(macroActor.data.data.bonuses.abilities.skill));
-		var tmpLength = tmp.indexOf(Guidd4);
-        tmp = tmp.substring(0, tmpLength) + tmp.substring(tmpLength+4, tmp.length);
-		obj['data.bonuses.abilities.skill'] = tmp;
 		macroActor.update(obj);
 	}
 }


### PR DESCRIPTION
While calculating skill check dices, the Foundry VTT DnD 5e module is checking for bonuses from abilities as well, and this is exactly the data.bonuses.abilities.check variable. So, if Guidd4 is added to data.bonuses.abilities.check and to data.bonuses.abilities.skill, first 1d4 is added checking abilities bonuses and second 1d4 is added from skills bonuses. Hence, dupicated d4.