### PR TITLE
Remove profanity from bane macro

### DIFF
--- a/5e/bane.js
+++ b/5e/bane.js
@@ -7,8 +7,8 @@
 
 //user modifiable declarations CHANGE AT YOUR OWN RISK
 const baneIconPath = 'icons/svg/degen.svg';
-let baneMsg = ' is Fucked!';
-let endbaneMsg = ' is no longer Fucked.';
+let baneMsg = ' is Baned!';
+let endbaneMsg = ' is no longer Baned.';
 
 //fixed declarations DO NOT MODIFY
 let macroActor = token.actor;


### PR DESCRIPTION
It was funny the first time it happened and my whole group got a laugh out of it, but it seems odd that this would be the _default_ message using the bane macro. 😬 These are marked as user configurable, so if you want to see `Skeleton is Fucked!`, you certainly still could.