### PR TITLE
Macro to unlink selected tokens from actor

### DIFF
--- a/token/unlink_tokens_from_actor.js
+++ b/token/unlink_tokens_from_actor.js
@@ -1,0 +1,9 @@
+// Unlinks all currently-selected tokens from their actors. This is useful if you're running
+// combat with several copies of the same enemy, as if they're all linked to the same actor,
+// applying damage to one applies damage to all. Select all the baddies and apply this macro
+// to be able to track their HP individually.
+
+canvas.tokens.updateAll(
+  t => ({ actorLink: false }),
+  t => t._controlled
+);


### PR DESCRIPTION
Create a new macro to unlink selected tokens from their actors.

Unlinks all currently-selected tokens from their actors. This is useful if you're running combat with several copies of the same enemy, as if they're all linked to the same actor, applying damage to one applies damage to all. Select all the baddies and apply this macro to be able to track their HP individually.