### PR TITLE
issue-219-fix-close-all-doors-macro-and-stop-using-deprecated-api

### DIFF
--- a/misc/close_all_doors.js
+++ b/misc/close_all_doors.js
@@ -3,6 +3,6 @@
  * Author: @Atropos#3814
  */
  
-canvas.walls.updateMany(canvas.scene.data.walls.map(w => {
-  return {_id: w._id, ds: w.ds === 1 ? 0 : w.ds};
+canvas.scene.updateEmbeddedDocuments("Wall", canvas.scene.data.walls.map(w => {
+  return {_id: w.id, ds: w.data.ds === 1 ? 0 : w.data.ds};
 }));


### PR DESCRIPTION
This is a fix for the issue #219. The macro now closes all doors again. Besides, it no longer uses a deprecated API. 