### PR TITLE
A macro for normalizing all lights after import

### DIFF
--- a/misc/batch_update_lights.js
+++ b/misc/batch_update_lights.js
@@ -1,0 +1,28 @@
+// Based on find_lights_by_color.js
+// Courtesy of @FloRad
+// This macro is intended to perform a batch update
+// of all lights in the current scene e.g. after
+// importing from Unversal Battle Map importer,
+// allowing you to set e.g. all wall torches identically.
+(async () => {
+        let foundLights = [];
+        let markingColor = "#eccd8b"
+        let newColor = "#fec80a"
+        let scene = game.scenes.active;
+    
+        canvas.lighting.placeables.forEach(l => { if (l.data.tintColor === markingColor && l.scene === scene) foundLights.push(l.id) })
+    
+        const updates = []
+        foundLights.forEach(id => {
+            updates.push({ _id: id, 
+                            tintColor: newColor, 
+                            darkness: {min:0.2, max:1.0}, 
+                            dim: 10, 
+                            bright: 5, 
+                            lightAnimation: {speed: 1, intensity: 3, type: "torch"} });
+        })
+    
+        await scene.updateEmbeddedEntity("AmbientLight", updates);
+    
+        console.log(foundLights)
+    })()


### PR DESCRIPTION
I don't know if it's better to just update the original macro find_lights_by_color.js.

The use case here is to update more than just the tint color, which wasn't obvious how to accomplish. I want to help people who are using DungeonDraft or DungeonFog to have consistent light sources. The use case is the user makes their map in DD/DF including light sources then imports the dd2vtt file and then runs this macro to get all the lights (wall torches) configured exactly how they want it.

In particular, updating the darkness and lightAnimation attributes isn't straightforward for novices, so I want them included here (or in the original find_lights_by_color.js).

I'm happy to move this code over to the find_lights_by_color.js file, I just don't know the norms for this repo.