### PR TITLE
Style fixes for Character Stat Roller

### DIFF
--- a/roll/character_stat_roller.js
+++ b/roll/character_stat_roller.js
@@ -28,7 +28,7 @@ let tableRows = '';
 let finalSum = 0;
 for(let {terms, total} of stats) {
   tableRows += `<tr style="text-align:center">`;
-  tableRows += terms[0].results.map(({result}) => `<td ${colorSetter(result, 1, faces)}>${result}</td>`).join('');
+  tableRows += terms[0].results.map(({result, discarded}) => `<td style="${colorSetter(result, 1, faces, discarded)}">${result}</td>`).join('');
   tableRows += `<td style="border-left:1px solid #000; ${colorSetter(total, totalLow, totalHigh)}">${total}</td></tr>`;
   finalSum += total;
 }
@@ -57,8 +57,9 @@ let content = `
 
 ChatMessage.create({content});
 
-function colorSetter(number,low,high)
+function colorSetter(number,low,high, discarded)
 {
+  if(discarded === true) return 'text-decoration:line-through;color:gray';
   if(number <= low) return 'color:red';
   if(number >= high) return 'color:green';
   return '';


### PR DESCRIPTION

I noticed that the colors were not getting applied properly to the individual rolls, and that has been fixed.

I also added detection for rolls that were marked as `discarded: true` to stylize them as grayed-out and with a strike-through.
# Before
![Screenshot from 2021-09-05 23-52-11](https://user-images.githubusercontent.com/491140/132173126-573ad3f1-5e25-4f5c-b9dd-46654ac4ba43.png)

# After
![Screenshot from 2021-09-05 21-15-19](https://user-images.githubusercontent.com/491140/132159880-c1a1e596-ecc7-4f27-b627-d057c12795a4.png)
