### PR TITLE
light_picker_color lightAlpha is a number

### DIFF
--- a/token/light_picker_color.js
+++ b/token/light_picker_color.js
@@ -48,7 +48,7 @@ function getLights() {
             label: light.label,
             callback: (html) => {
                 const newColor = html.find("#color").val();
-                const newAlpha = html.find("#alpha").val();
+                const newAlpha = Number(html.find("#alpha").val());
                 var data = light.data;
                 tokenUpdate(Object.assign(data, {lightColor: newColor, lightAlpha: newAlpha}));
             }


### PR DESCRIPTION
this fixes a bug in light_picker_color.js that prevents the token's
light from being updated with this error message:

TokenData lightAlpha is not a number between 0 and 1