### PR TITLE
Create rebind_token_actors.js

### DIFF
--- a/misc/rebind_token_actors.js
+++ b/misc/rebind_token_actors.js
@@ -1,0 +1,29 @@
+// Rebinds the actor for all selected tokens.
+// Requirements: 
+//  - the actor must be present in the "Actor Directory"
+//  - actor name can't contain either '/' or '.'
+
+// Any Token with an altered name and an img path attached 
+// will look up the default actor name via provided URL.
+// Very useful when using eg. Plutonium in combination with
+// 5e.tools for importing creatures or other actors.
+let tname, results, str, arr;
+
+const dir = new ActorDirectory();
+
+for (const token of canvas.tokens.controlled) {
+   tname = token.name;
+   results = dir.documents.filter(obj => {if(obj.data.name === tname){return obj;}})
+   if(results.length === 0){
+       if(token.data.img){
+//      Possible optimization: regEx look-up for any word character pre '.' and post '/'
+        str = token.data.img;
+        arr = str.split('/');
+        tname = arr[arr.length-1].split('.')[0];
+        results = dir.documents.filter(obj => {if(obj.data.name === tname){return obj;}})
+       }
+   }
+   if(results.length > 0){
+        await token.update({'actorId':results[0].data._id});
+   }
+}


### PR DESCRIPTION
After the unfortunate event of **redacted** shutting down, all my scene's tokens were broken. I used this script to rebind all token actors so the tokens weren't broken anymore (eg. no token image, hp bar). 

Please use this macro carefully as some of you may use unlinked tokens on your scenes.