### PR TITLE
Update to work with ActiveEffects

### DIFF
--- a/token/remove_conditions.js
+++ b/token/remove_conditions.js
@@ -1,5 +1,6 @@
 (async () => {
-  for ( let token of canvas.tokens.controlled ){
-    await token.update({"effects": []});
-  }
+  for ( let token of canvas.tokens.controlled ) {
+    let effectsToDelete = token.actor.effects.filter(e => e.sourceName === "None")
+      .map(e => { return e.id }); // documents api expects array of ids
+    await token.actor.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
 })();

--- a/token/remove_conditions.js
+++ b/token/remove_conditions.js
@@ -3,4 +3,4 @@
     let effectsToDelete = token.actor.effects.filter(e => e.sourceName === "None")
       .map(e => { return e.id }); // documents api expects array of ids
     await token.actor.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
-})();
+}})();


### PR DESCRIPTION
This macro didn't seem to work with newer versions of foundry since the addition of ActiveEffects into the core app. This should properly delete the effect from the actor sheets for each selected token, which will update the token correspondingly. It should leave custom ActiveEffects created by modules or directly in the sheet intact.