### PR TITLE
Update macro for selecting like tokens

### DIFF
--- a/token/actor_selector.js
+++ b/token/actor_selector.js
@@ -4,6 +4,11 @@
 // eg: if you have a group of goblins mixed in with kobolds and you want to move all goblins
 // select 1 goblin and run this macro
 // all Goblins will now be selected
+// this should still work in conjunction with Token Mold
+let selectedId = canvas.tokens.controlled[0].document.actor.id
 
-let tokens = canvas.tokens.placeables.filter(i => i.data.name === token.data.name)
-tokens.forEach(i => i.control({ releaseOthers: false }))
+canvas.tokens.ownedTokens.forEach(i => {
+  if(i.data.actorId == selectedId) {
+    i.control({releaseOthers: false})
+  }
+})


### PR DESCRIPTION
The previous version was erroring out on v9. I went to update it and noticed it doesn't work with token mold when you add adjectives to the tokens. This *should do the trick.