### PR TITLE
Update pf2e/vision_configuration.js for FoundryVTT 9

### DIFF
--- a/pf2e/vision_configuration.js
+++ b/pf2e/vision_configuration.js
@@ -141,15 +141,7 @@ new Dialog({
         }
         // Update Token
         console.log(token);
-        token.update({
-          vision: true,
-          dimSight: dimSight,
-          brightSight: brightSight,
-          dimLight: dimLight,
-          brightLight:  brightLight,
-          lightAngle: lightAngle,
-          lockRotation: lockRotation
-        });
+        token.document.update({light:{bright: brightLight, dim: dimLight, angle: lightAngle}});
       }
     }
   }


### PR DESCRIPTION
This macro was broken after the light and vision changes in the new Foundry version. This should fix it.