### PR TITLE
Update some of the 5e macros to be v9-compatible

### DIFF
--- a/5e/fighter_second_wind.js
+++ b/5e/fighter_second_wind.js
@@ -41,7 +41,7 @@ if (macroActor !== undefined && macroActor !== null) {
     if (checkResource(macroActor)) {
       // Calculate string to roll based on fighter level
       let fighterLvl = fighter.data.data.levels;
-      let healRoll = new Roll(`1d10 + ${fighterLvl}`).roll();
+      let healRoll = await new Roll(`1d10 + ${fighterLvl}`).roll();
 
       ChatMessage.create({
         user: game.user._id,

--- a/5e/fighter_second_wind.js
+++ b/5e/fighter_second_wind.js
@@ -44,7 +44,7 @@ if (macroActor !== undefined && macroActor !== null) {
       let healRoll = await new Roll(`1d10 + ${fighterLvl}`).roll();
 
       ChatMessage.create({
-        user: game.user._id,
+        user: game.user.id,
         speaker: ChatMessage.getSpeaker({
           token: actor,
         }),

--- a/5e/lay_on_hands.js
+++ b/5e/lay_on_hands.js
@@ -57,7 +57,7 @@ else
                     let flavor = `<strong>${html.find('#flavor')[0].value}</strong><br>`;
                     if (targetActor.permission !== CONST.ENTITY_PERMISSIONS.OWNER)
                         // We need help applying the healing, so make a roll message for right-click convenience.
-                        new Roll(`${number}`).roll().toMessage({
+                        await new Roll(`${number}`).toMessage({
                             speaker: ChatMessage.getSpeaker(),
                             flavor: `${actorData.name} lays hands on ${targetActor.data.name}.<br>${flavor}
                             <p><em>Manually apply ${number} HP of healing to ${targetActor.data.name}</em></p>` });

--- a/5e/wild_magic.js
+++ b/5e/wild_magic.js
@@ -1,9 +1,9 @@
 function printMessage(message){
         let chatData = {
-                user : game.user._id,
+                user : game.user.id,
                 content : message,
                 blind: true,
-                whisper : game.users.entities.filter(u => u.isGM).map(u => u._id)
+                whisper : game.users.filter(u => u.isGM).map(u => u.id)
         };
 
         ChatMessage.create(chatData,{});        
@@ -11,11 +11,11 @@ function printMessage(message){
 
 
 const roll = new Roll(`1d20`);
-let result = roll.roll();
+let result = await roll.roll();
 
-if (result.results[0] == 1) {
+if (result.total == 1) {
     printMessage('<p style="color:red;">Wild magic has been triggered.</p>');
 }
 else{
-    printMessage("Wild magic was not triggered on a " + result.results[0]);
+    printMessage("Wild magic was not triggered on a " + result.total);
 }


### PR DESCRIPTION
Some of the 5e macros weren't updated in v8 to some of the changes in that version and break now that v9 has removed those deprecated methods. I started out just fixing `roll()` but found a few more changes that needed to be done. This fixes:

- Divine Smite
- Second Wind
- Lay on Hands
- Wild Magic