### PR TITLE
Update roll and token macros for v9

### DIFF
--- a/roll/average_roll_results.js
+++ b/roll/average_roll_results.js
@@ -15,17 +15,19 @@ let dialogue = new Dialog({
                 const chatLog = game.messages;
                 let rolls = 0;
                 let total = 0;
-                
+
                 chatLog.forEach(entry => {
-                    const {terms} = entry._roll;
-                    terms
-                        .filter(die => die.faces === diceToCheck)
-                        .forEach(die => {
-                            rolls = rolls + die.number;
-                            total = total + die.total;
-                        })
+                    if (entry.roll) {
+                        const { terms } = entry.roll;
+                        terms
+                            .filter(die => die.faces === diceToCheck)
+                            .forEach(die => {
+                                rolls = rolls + die.number;
+                                total = total + die.total;
+                            })
+                    }
                 });
-                
+
                 console.log(rolls, total);
 
                 let dialogue = new Dialog({

--- a/roll/roll_ammunition_die.js
+++ b/roll/roll_ammunition_die.js
@@ -27,7 +27,7 @@ Example:
     1: 0
   }
 
-  function rollDie(html, ammo) {
+  async function rollDie(html, ammo) {
     const ammoId = html[0].querySelector('input:checked')?.value;
     if (!ammoId) {
       ui.notifications.error("No ammunition selected.");
@@ -38,8 +38,8 @@ Example:
 
     const die = dice[ammoId];
     const roll = new Roll(`1d${die}`);
-    roll.roll();
-    dice[ammoId] = roll.result == 1 ? (dieMap[die] || die - 1) : die;
+    await roll.roll();
+    dice[ammoId] = roll.total === 1 ? (dieMap[die] || die - 1) : die;
     token.actor.unsetFlag('world', 'ammunition-dice')
       .then(entity => entity.setFlag('world', 'ammunition-dice', dice));
     roll.toMessage({
@@ -81,7 +81,7 @@ Example:
       title: "Roll ammunition die",
       content: form,
       buttons: {
-        yes: { label: "Roll", callback: html => rollDie(html, ammunition) },
+        yes: { label: "Roll", callback: async html => rollDie(html, ammunition) },
         no: (game.user.isGM ? { label: "Update", callback: html => updateDice(html) } : { label: "Cancel" })
       },
       default: (game.user.isGM ? 'no' : 'yes')

--- a/roll/roll_die.js
+++ b/roll/roll_die.js
@@ -4,7 +4,6 @@
     //n: number of dice
     //x: value (number of sides) on die
 const roll = new Roll(`1d6`);
-roll.roll();
-roll.toMessage({
+await roll.toMessage({
     flavor: "Sneak Attack Damage",
 });

--- a/roll/token_hp.js
+++ b/roll/token_hp.js
@@ -18,7 +18,7 @@ async function rollHP(token, index){
 		
 	if (actor.data.type != "npc" || !formula) return;
 	
-	let hp = new Roll(formula).roll().total;
+	let hp = (await new Roll(formula).roll()).total;
 	
 	await actor.update({"data.attributes.hp.value": hp, "data.attributes.hp.max": hp});
 	
@@ -30,7 +30,7 @@ function printMessage(message){
 		user : game.user._id,
 		content : message,
 		blind: true,
-		whisper : game.users.entities.filter(u => u.isGM).map(u => u._id)
+		whisper : game.users.filter(u => u.isGM).map(u => u.id)
 	};
 
 	ChatMessage.create(chatData,{});	

--- a/roll/wandering_monsters.js
+++ b/roll/wandering_monsters.js
@@ -1,22 +1,19 @@
 // setting variables
-let tableName = "Wandering Monsters";
-let msgContent = 'Wandering Monster roll was: ';
-let result = '';
+const tableName = "Wandering Monsters";
+const msgContent = "Wandering Monster roll was: ";
 
 // roll to check for wandering monster
-result = new Roll(`1d20`).roll().total;
+const result = (await new Roll(`1d20`).roll()).total;
 
 // create the message
-if(result !== '') {
-  let chatData = {
-    content: msgContent + result,
-    whisper: game.users.entities.filter(u => u.isGM).map(u => u._id)
-  };
-  ChatMessage.create(chatData, {});
-}
+const chatData = {
+  content: msgContent + result,
+  whisper: game.users.filter(u => u.isGM).map((u) => u.id),
+};
+ChatMessage.create(chatData);
 
 // In this example, a roll between 17-20 will generate a roll from the Table. Tweak as needed!
 if (result >= 17) {
-  const table = game.tables.entities.find(t => t.name === tableName);
+  const table = game.tables.getName(tableName);
   table.draw();
 }

--- a/token/end_turn.js
+++ b/token/end_turn.js
@@ -11,30 +11,13 @@ the turn when the current actor in the turn order is owned by you.
 Based on the work of reddit user serrag97: https://www.reddit.com/r/FoundryVTT/comments/j1b8gs/next_turn_shortcut/
 */
 
-main()
+// check if the user is a GM
+const isGM = game.user.isGM;
+// check if the user owns the combatant whose turn it is
+const isOwner = game.combat.combatant.isOwner;
 
-async function main() {
-    try {
-        // If you have the Gamemaster role, you can advance
-        // the turn for any actor
-        const isGM = game.users.get(game.userId).hasRole(4);
-        if (isGM) {
-            game.combats.active.nextTurn();
-        }
-        else {
-            for(let token of canvas.tokens.controlled) {
-                if(token.id === game.combats.active.current.tokenId) {
-                    game.combats.active.nextTurn();
-                    return;
-                }
-            }
-
-            ui.notifications.info('As a player you can only advance your turn');
-        }
-
-        return;
-    } catch(e) {
-        ui.notifications.error(e);
-        return;
-    }
+if (isGM || isOwner) {
+  game.combat.nextTurn();
+} else {
+  ui.notifications.info("As a player you can only advance your turn");
 }

--- a/token/light_picker_color.js
+++ b/token/light_picker_color.js
@@ -1,5 +1,5 @@
 function tokenUpdate(data) {
-    canvas.tokens.controlled.map(token => token.update(data));
+    canvas.tokens.controlled.map(token => token.document.update({ light: data }));
 }
 
 const isGM = game.user.isGM;
@@ -8,8 +8,8 @@ let color = "#ffffff";
 let alpha = 1.0;
 let tokens = canvas.tokens.controlled;
 if (tokens.length === 1) {
-    color = tokens[0].data.lightColor;
-    alpha = tokens[0].data.lightAlpha;
+    color = tokens[0].data.light.color ?? color;
+    alpha = tokens[0].data.light.alpha ?? alpha;
 }
 
 const torchAnimation = {type: "torch", speed: 1, intensity: 1};
@@ -17,27 +17,27 @@ const energyShield = {type: "energy", speed: 1, intensity: 1};
 const lights = {
     none: {
         label: "None",
-        data: {dimLight: null, brightLight: null, lightAngle: 360}
+        data: {dim: null, bright: null, angle: 360}
     },
     torch: {
         label: "Torch",
-        data: {dimLight: 40, brightLight: 20, lightAngle: 360, lightAnimation: torchAnimation}
+        data: {dim: 40, bright: 20, angle: 360, animation: torchAnimation}
     },
     light: {
         label: "Light cantrip",
-        data: {dimLight: 40, brightLight: 20, lightAngle: 360, lightAnimation: {type: "none"}}
+        data: {dim: 40, bright: 20, angle: 360, animation: {type: "none"}}
     },
     lamp: {
         label: "Lamp",
-        data: {dimLight: 45, brightLight: 15, lightAngle: 360, lightAnimation: torchAnimation}
+        data: {dim: 45, bright: 15, angle: 360, animation: torchAnimation}
     },
     shield: {
         label: "Shield",
-        data: {dimLight: 0.5, brightLight: 0, lightAngle: 360, lightAnimation: energyShield}
+        data: {dim: 0.5, bright: 0, angle: 360, animation: energyShield}
     },
     bullseye: {
         label: "Bullseye Lantern",
-        data: {dimLight: 120, brightLight: 60, lightAngle: 45, lightAnimation: torchAnimation}
+        data: {dim: 120, bright: 60, angle: 45, animation: torchAnimation}
     }
 };
 
@@ -50,7 +50,7 @@ function getLights() {
                 const newColor = html.find("#color").val();
                 const newAlpha = Number(html.find("#alpha").val());
                 var data = light.data;
-                tokenUpdate(Object.assign(data, {lightColor: newColor, lightAlpha: newAlpha}));
+                tokenUpdate(Object.assign(data, {color: newColor, alpha: newAlpha}));
             }
         }
     });

--- a/token/rename_token_and_actor.js
+++ b/token/rename_token_and_actor.js
@@ -4,7 +4,7 @@ async function renameToken(newName)
 {
     for (const token of canvas.tokens.controlled) {
         console.log(newName);
-        await token.update({'name':newName});
+        await token.document.update({'name':newName});
         await token.actor.update({'name' : newName});
     }
 }            

--- a/token/set_name_and_bars.js
+++ b/token/set_name_and_bars.js
@@ -11,4 +11,4 @@ const tokens = canvas.tokens.placeables.map(token => {
   };
 });
 
-canvas.scene.updateEmbeddedEntity('Token', tokens)
+canvas.scene.updateEmbeddedDocuments('Token', tokens)

--- a/token/token_multi_select.js
+++ b/token/token_multi_select.js
@@ -24,7 +24,7 @@ if (actor !== undefined && actor !== null) {
         icon: '<i class="fas fa-check"></i>',
         label: "Do it!",
         callback: () =>
-          token.update({
+          token.document.update({
             img: token.data.img.slice(0, token.data.img.lastIndexOf('_')) + document.getElementById("token").value
           })
       },


### PR DESCRIPTION
I made a pass over all the roll and token macros whose last commit was over 2 months ago. Some were already updated for v9 and that seemed to be a good way to weed those out. Some of them still worked so I didn't touch them, but there were ten that needed fixes. Most of the updates are just the fixes necessary to make them work, but I did some major refactoring of `roll/end_turn.js`  since it was overly complicated.