### PR TITLE
fix #298 - refactor and fix max npc hp script

### DIFF
--- a/misc/max_npc_hp.js
+++ b/misc/max_npc_hp.js
@@ -1,21 +1,27 @@
 // A simple macro for maximizing NPC HP
 
-const dir = new ActorDirectory();
 const regEx = /(\d+d\d+)/;
 
-dir.documents.forEach(function(obj){
-    let formula, match, math, solution;
-    let attributes = obj.data.data.attr;
-    if(!attributes){ return; }
-    formula = attributes.hp.formula;
-    if(!formula){return;}
-    match    = formula.match(regEx);
-    if(!match){return;}
-    math     = match[0].replace('d','*');
-    math     = '('+math+')';
-    formula  = formula.replace(match[0], math);
-    solution = eval(formula);
-    obj.data.data.attr.hp.value = solution;
-    obj.data.data.attr.hp.max = solution;
-    await obj.update();
+// Choose one of the following to update by uncommenting one of the two lines below
+//const actors = game.actors; // update all actors in the sidebar
+const actors = canvas.tokens.controlled.map((t) => t.actor); // update all selected tokens
+
+actors
+  .filter((actor) => actor.type === "npc")
+  .forEach(async (actor) => {
+    const formula = actor.data.data?.attributes?.hp?.formula;
+    if (!formula) return;
+
+    const match = formula.match(regEx);
+    if (!match) return;
+
+    const maxDice = "(" + match[0].replace("d", "*") + ")";
+    const maxFormula = formula.replace(match[0], maxDice);
+    const maxHp = eval(maxFormula);
+
+    const data = {
+      "data.attributes.hp.value": maxHp,
+      "data.attributes.hp.max": maxHp,
+    };
+    await actor.update(data);
   });

--- a/misc/max_npc_hp.js
+++ b/misc/max_npc_hp.js
@@ -1,7 +1,5 @@
 // A simple macro for maximizing NPC HP
 
-const regEx = /(\d+d\d+)/;
-
 // Choose one of the following to update by uncommenting one of the two lines below
 //const actors = game.actors; // update all actors in the sidebar
 const actors = canvas.tokens.controlled.map((t) => t.actor); // update all selected tokens
@@ -12,16 +10,10 @@ actors
     const formula = actor.data.data?.attributes?.hp?.formula;
     if (!formula) return;
 
-    const match = formula.match(regEx);
-    if (!match) return;
-
-    const maxDice = "(" + match[0].replace("d", "*") + ")";
-    const maxFormula = formula.replace(match[0], maxDice);
-    const maxHp = eval(maxFormula);
-
+    const roll = await new Roll(formula).roll({ maximize: true });
     const data = {
-      "data.attributes.hp.value": maxHp,
-      "data.attributes.hp.max": maxHp,
+      "data.attributes.hp.value": roll.total,
+      "data.attributes.hp.max": roll.total,
     };
     await actor.update(data);
   });


### PR DESCRIPTION
I started out just fixing the problem with `await` inside the loop, but it still didn't work. I don't know what system it was originally designed for, but it looks really close to dnd5e so made it work with that. Here's the changes made during refactoring:

- filtered on `npc` type instead of relying on `formula` not being there for `characters`
- got attributes from `attributes` instead of `attr`
- use Roll's maximize option instead of a regex to do the math itself
- added the choice whether to update all NPCs in the sidebar (risky) or just the selected tokens (less risky)