### PR TITLE
Fix bulk folder permission updating

### DIFF
--- a/misc/folder_permission.js
+++ b/misc/folder_permission.js
@@ -91,7 +91,7 @@ async function repermission(currentFolder, desiredPermission, recurse) {
 		currentFolder.content.forEach(async doc => {
 			const newPerms = duplicate(doc.data.permission);
 			newPerms.default = Number(desiredPermission);
-			await doc.data.update({ permission: newPerms });
+			await doc.update({ permission: newPerms });
 		});
 	}
 


### PR DESCRIPTION
The issue was that we were not saving the actual objects, so the changes were not applied properly. It appears to work perfectly now!

Addresses https://github.com/foundry-vtt-community/macros/issues/288