### PR TITLE
Create apply_damage.js

### DIFF
--- a/5e/apply_damage.js
+++ b/5e/apply_damage.js
@@ -1,0 +1,48 @@
+// Displays a prompt which asks for an amount of damage to inflict
+// Inflicts the input damage amount to all selected tokens
+
+let content = `
+  <form>
+    <div class="form-group">
+      <label for="id="damage-amount">Damage</label>
+      <input id="damage-amount" type="number" name="inputField" autofocus>
+    </div>
+  </form>`
+
+new Dialog({
+  title: 'How much damage should be applied (negative for healing)?',
+  content: content,
+  buttons:{
+    yes: {
+      icon: "<i class='fas fa-check'></i>",
+      label: `Apply Damage`
+    }
+  },
+
+  default:'yes',
+
+  close: html => {
+    let result = html.find('input[name=\'inputField\']');
+    if (result.val() !== '') {
+      let damage = result.val();
+      let allSelected = canvas.tokens.controlled
+
+      allSelected.forEach(selected => {
+        let actor = selected.actor
+        let hp = actor.data.data.attributes.hp.value
+        let maxHp = actor.data.data.attributes.hp.max
+
+        let updatedHp = damage > hp ? 0 : hp - damage
+
+        actor.update({'data.attributes.hp.value': updatedHp > maxHp ? maxHp : updatedHp})
+
+        console.log(actor)
+      })
+    }
+  }
+}).render(true);
+
+(async () => {
+await new Promise(resolve => setTimeout(resolve, 20));
+let input = $('#damage-amount').focus();
+})();


### PR DESCRIPTION
I use this macro because my group plays in-person and we use physical dice rather than rolling in Foundry. Instead of calculating how much HP each target would have left and manually updating their HP, this macro allows for simply selecting however many targets you wish, running the macro, and applying damage. It automatically accounts for maximum HP in the case of "negative damage" (for healing a target) as well as accounting for when a target reaches 0 HP.