### PR TITLE
Fixed change initiative skill when choosing perception in Pf2e

### DIFF
--- a/pf2e/change_initiative_skill.js
+++ b/pf2e/change_initiative_skill.js
@@ -6,7 +6,7 @@ async function setInitSkill(skillname)
 {
     canvas.tokens.controlled.forEach(async function(changetoken){
         if(changetoken.actor.data.type!="character"){
-            let skillval=changetoken.actor.data.data.skills[skillname].totalModifier;
+            let skillval=skillname=="perception"? changetoken.actor.data.data.attributes.perception.totalModifier : changetoken.actor.data.data.skills[skillname].totalModifier;
             await changetoken.actor.update({
             'data.attributes.initiative.ability':skillname,
             'data.attributes.initiative.totalModifier':skillval


### PR DESCRIPTION
The macro for changing initiative skill for Pf2e doesn't work in choosen "Perception" from the first menu.

Perception is not a skill per se in Pf2e, and the actor.data.data.skills does not contain a "perception" field. Perception is in the actor.data.data.attributes.perception instead.

These change fixes this issue