### PR TITLE
Update clone_token_actor.js for Foundry v10

### DIFF
--- a/token/clone_token_actor.js
+++ b/token/clone_token_actor.js
@@ -8,5 +8,7 @@
 const actorNameSuffix = "_cloned";
 
 canvas.tokens.controlled.forEach(o => {
-  o.actor.clone({ name: o.name + actorNameSuffix }, {save: true});
+  Actor.create(o.actor).then(a => {
+    a.update({name: a.name + actorNameSuffix});
+  });
 });


### PR DESCRIPTION
The macro currently fails with:
"Error: Managing embedded Documents which are not direct descendants of
a primary Document is un-supported at this time."

This fix uses create() instead of clone() and then updates the new
actor's name.