### PR TITLE
Create Recover Item Uses Macro

### DIFF
--- a/5e/Recover Item Uses Macro
+++ b/5e/Recover Item Uses Macro
@@ -1,0 +1,72 @@
+const token = canvas.tokens.controlled[0];
+const actor = token.actor;
+const item = actor.items.find(i => i.name === "Throwing Cards");    // item name
+
+
+const config = {
+    Actor: {  
+        items: {
+            name: "Throwing Cards"  // Item name
+        },
+        system: {
+            activities: {
+                uses: {
+                    spent: item.system.uses.spent || 0, 
+                    max: 52                          // item max uses    
+                }
+            }
+        }
+    }
+};
+
+
+const currentSpent = config.Actor.system.activities.uses.spent;
+
+const max = config.Actor.system.activities.uses.max;
+
+ // change to skill or ability that makes sense
+
+const perceptionBonus = actor.system.skills.prc.mod;  
+
+// update to the roll you want to make and the skill or ability
+
+async function calculateIncreaseAmount(perceptionBonus) {
+    const roll = new Roll("1d5");
+    await roll.evaluate();  // Await the roll evaluation
+    return roll.total + perceptionBonus; 
+}
+
+// Calculate the increase amount
+
+const increaseAmount = await calculateIncreaseAmount(perceptionBonus);
+
+// update for your items max uses
+
+const currentUses = currentSpent || 0;
+const maxUses = parseInt(max) || 52;
+
+// Calculate new uses
+
+const newUses = Math.min(currentUses - increaseAmount, maxUses);
+
+async function updateSpent(newSpent) { 
+    try {
+        await item.update({ "system.uses.spent": newSpent });
+        console.log("Item updated successfully.");
+    } catch (updateError) {
+        console.error("Error updating item:", updateError);
+    }
+}
+
+// Update the spent value
+
+await updateSpent(newUses);   
+
+ChatMessage.create({
+        content: `${actor.name} searched around and found ${increaseAmount} undamaged ${item.name}.`,
+        speaker: { alias: actor.name },
+    });
+
+// Check the updated value
+
+console.log("Updated spent value:", config.Actor.system.activities.use);


### PR DESCRIPTION
I made a new item feature and added the macro action. That makes it so that when you drop the new feature item on a token it becomes available through the module Token Action HUD D&D 5e. This should work the same with any module you use that displays token feature abilities. The macro just references the token and the item. It also works as a standalone macro; the roll just happens automatically and isn’t displayed in chat. Simply select the token with the item you made the macro update and click the macro. 

This macro finds the item in a tokens inventory and then updates the items uses based on the roll and skill/attribute you pick.  I made a custom weapon  (Throwing Cards) with 52 uses (the number of cards in a deck) and then made a feature that runs this macro. I added the perception bonus because it’s flavored like the player has looked around and found undamaged cards to put back in the deck. 

This macro needs some personalization for it to be usable. You need to update the name of the item, max uses, what roll you want to happen, and what skill or ability you want to add. All of that can be customized. You can remove the parts about adding the skill or ability.  The most important part is to make sure the array for const config is correct. You’ll need to export the json file for the item you want to reference. Right click on the item and select export data and open the file with any writing program. I recommend using Notepad++ because it will display the code properly and it’s easier to see the details for the array. From there you simply define what path the macro needs to take to find the uses / charges / whatever you want to update.