### PR TITLE
Update shrink_or_enlarge.js to fix issue #334

### DIFF
--- a/token/shrink_or_enlarge.js
+++ b/token/shrink_or_enlarge.js
@@ -2,7 +2,7 @@
 
 const updates = [];
 for (let token of canvas.tokens.controlled) {
-  let newSize = (token.data.height == 1 && token.data.width == 1) ? 2 : 1;
+  let newSize = (token.document.height == 1 && token.document.width == 1) ? 2 : 1;
   updates.push({
     _id: token.id,
     height: newSize,


### PR DESCRIPTION
Currently, this macro fails because of using an outdated field, this updates them to the correct fields, fixing issue #334 